### PR TITLE
Chore: use `CollapsableSection` from `@grafana/ui`

### DIFF
--- a/src/components/ElementSections/ElementSections.tsx
+++ b/src/components/ElementSections/ElementSections.tsx
@@ -123,6 +123,7 @@ export const ElementSections: React.FC<Props> = ({
                     {replaceVariables(section.name)} [{section.id}]
                   </>
                 }
+                unmountContentWhenClosed
               >
                 {children}
               </CollapsableSection>


### PR DESCRIPTION
only difference seems to be text color of heading, see below

| before | after |
| --- | --- |
| <img width="755" height="375" alt="image" src="https://github.com/user-attachments/assets/8971e280-364c-42e9-96f7-3a1ede6a7982" /> | <img width="755" height="383" alt="image" src="https://github.com/user-attachments/assets/7b61dd06-7468-4353-b550-aecd354bc428" /> |

For https://github.com/grafana/grafana/issues/112873