### PR TITLE
Chore: Move `useDashboardRefresh` into the repo and replace usage

### DIFF
--- a/.config/types/global.d.ts
+++ b/.config/types/global.d.ts
@@ -1,6 +1,10 @@
+import { SceneObject } from '@grafana/scenes';
+
 /**
  * __grafanaSceneContext type to prevent TS error
  */
-interface Window {
-  __grafanaSceneContext: unknown;
+declare global {
+  interface Window {
+    __grafanaSceneContext?: SceneObject;
+  }
 }

--- a/src/__mocks__/@volkovlabs/components.tsx
+++ b/src/__mocks__/@volkovlabs/components.tsx
@@ -83,7 +83,6 @@ const NumberInputMock: React.FC<Props> = ({ value, onChange, min, max, step, ...
 const NumberInput = jest.fn(NumberInputMock);
 
 const useDatasourceRequest = jest.fn();
-const useDashboardRefresh = jest.fn();
 
 /**
  * Mock DatasourcePayloadEditor
@@ -120,5 +119,4 @@ module.exports = {
   NumberInput,
   DatasourcePayloadEditor,
   useDatasourceRequest,
-  useDashboardRefresh,
 };

--- a/src/components/FormElements/FormElements.test.tsx
+++ b/src/components/FormElements/FormElements.test.tsx
@@ -14,11 +14,6 @@ import { FormElements } from './FormElements';
 jest.useFakeTimers();
 
 /**
- * Mock @volkovlabs/components
- */
-jest.mock('@volkovlabs/components');
-
-/**
  * Replace variables
  */
 const replaceVariablesMock = (code: string) => code;

--- a/src/components/FormPanel/FormPanel.test.tsx
+++ b/src/components/FormPanel/FormPanel.test.tsx
@@ -1,9 +1,9 @@
 import { AppEvents, EventBusSrv, FieldType, LoadingState, toDataFrame } from '@grafana/data';
 import { getAppEvents, RefreshEvent } from '@grafana/runtime';
-import { sceneGraph } from '@grafana/scenes';
+import { sceneGraph, SceneObject } from '@grafana/scenes';
 import { PanelContextProvider } from '@grafana/ui';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { useDashboardRefresh, useDatasourceRequest } from '@volkovlabs/components';
+import { useDatasourceRequest } from '@volkovlabs/components';
 import React, { ReactElement } from 'react';
 
 import {
@@ -38,6 +38,12 @@ import {
 
 import { FormElements } from '../FormElements';
 import { FormPanel } from './FormPanel';
+import { useDashboardRefresh } from '../../hooks';
+
+jest.mock('../../hooks', () => ({
+  ...jest.requireActual('../../hooks'),
+  useDashboardRefresh: jest.fn(),
+}));
 
 /**
  * Mock Form Elements
@@ -2974,11 +2980,7 @@ describe('Panel', () => {
 
       jest.mocked(useDashboardRefresh).mockReturnValue(() => onRefresh());
 
-      window.__grafanaSceneContext = {
-        body: {
-          text: 'hello',
-        },
-      };
+      window.__grafanaSceneContext = {} as SceneObject;
 
       jest.mocked(sceneGraph.getTimeRange).mockReturnValue({
         onRefresh: jest.fn(),
@@ -3983,11 +3985,7 @@ describe('Panel', () => {
 
       jest.mocked(useDashboardRefresh).mockReturnValue(() => onRefresh());
 
-      window.__grafanaSceneContext = {
-        body: {
-          text: 'hello',
-        },
-      };
+      window.__grafanaSceneContext = {} as SceneObject;
 
       jest.mocked(sceneGraph.getTimeRange).mockReturnValue({
         onRefresh: jest.fn(),

--- a/src/components/FormPanel/FormPanel.tsx
+++ b/src/components/FormPanel/FormPanel.tsx
@@ -21,7 +21,7 @@ import {
   toDataQueryResponse,
 } from '@grafana/runtime';
 import { Alert, Button, ConfirmModal, LoadingBar, usePanelContext, useStyles2, useTheme2 } from '@grafana/ui';
-import { useDashboardRefresh, useDatasourceRequest } from '@volkovlabs/components';
+import { useDatasourceRequest } from '@volkovlabs/components';
 import { CustomButtonsRow } from 'components/CustomButtonsRow';
 import { debounce, isEqual } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -36,7 +36,7 @@ import {
   ResetActionMode,
   TEST_IDS,
 } from '@/constants';
-import { useFormLayout, useMutableState } from '@/hooks';
+import { useDashboardRefresh, useFormLayout, useMutableState } from '@/hooks';
 import {
   ButtonVariant,
   FormElement,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useAutoSave';
+export * from './useDashboardRefresh';
 export * from './useFormLayout';
 export * from './useMutableState';
 export * from './useQueryFields';

--- a/src/hooks/useDashboardRefresh.test.ts
+++ b/src/hooks/useDashboardRefresh.test.ts
@@ -1,0 +1,80 @@
+import { EventBusSrv } from '@grafana/data';
+import { getAppEvents } from '@grafana/runtime';
+import { sceneGraph } from '@grafana/scenes';
+import { renderHook } from '@testing-library/react';
+
+import { useDashboardRefresh } from './useDashboardRefresh';
+
+/**
+ * Mock @grafana/scenes
+ */
+jest.mock('@grafana/scenes', () => ({
+  sceneGraph: {
+    getTimeRange: jest.fn(),
+  },
+}));
+
+/**
+ * Mock @grafana/runtime
+ */
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getAppEvents: jest.fn(),
+}));
+
+describe('useDashboardRefresh', () => {
+  /**
+   * App Events
+   */
+  const appEvents = new EventBusSrv();
+
+  /**
+   * Enable Scene
+   */
+  const enableScene = () => {
+    Object.defineProperty(global, '__grafanaSceneContext', {
+      writable: true,
+      value: {},
+    });
+  };
+
+  beforeEach(() => {
+    jest.mocked(getAppEvents).mockReturnValue(appEvents);
+  });
+
+  afterEach(() => {
+    appEvents.removeAllListeners();
+    Object.defineProperty(global, '__grafanaSceneContext', {
+      writable: true,
+      value: undefined,
+    });
+  });
+
+  it('Should refresh non scene dashboard', () => {
+    const { result } = renderHook(() => useDashboardRefresh());
+
+    let refreshEvent;
+
+    appEvents.getStream({ type: 'variables-changed' } as never).subscribe((event) => (refreshEvent = event));
+
+    result.current();
+
+    expect(refreshEvent).toEqual({
+      type: 'variables-changed',
+      payload: { refreshAll: true },
+    });
+  });
+
+  it('Should refresh scene dashboard', () => {
+    enableScene();
+
+    const onRefresh = jest.fn();
+    jest.mocked(sceneGraph.getTimeRange).mockReturnValue({ onRefresh } as never);
+
+    const { result } = renderHook(() => useDashboardRefresh());
+
+    result.current();
+
+    expect(onRefresh).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDashboardRefresh.ts
+++ b/src/hooks/useDashboardRefresh.ts
@@ -1,0 +1,22 @@
+import { getAppEvents } from '@grafana/runtime';
+import { sceneGraph } from '@grafana/scenes';
+import { useCallback } from 'react';
+
+/**
+ * Use Dashboard Refresh
+ */
+export const useDashboardRefresh = () => {
+  return useCallback(() => {
+    /**
+     * Refresh on scene dashboard
+     */
+    if (window.__grafanaSceneContext) {
+      return sceneGraph.getTimeRange(window.__grafanaSceneContext)?.onRefresh();
+    }
+
+    /**
+     * Refresh dashboard
+     */
+    return getAppEvents().publish({ type: 'variables-changed', payload: { refreshAll: true } });
+  }, []);
+};


### PR DESCRIPTION
- moves the `useDashboardRefresh` hook into the repo and replaces usage

For https://github.com/grafana/grafana/issues/112873