### PR TITLE
security: disable postinstall/lifecycle scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 
 - Patched transitive dependencies with known vulnerabilities, including a critical CVE in `protobufjs`.
+- Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
+
+### Changed
+
+- Plugin now supports Grafana 13 and React 19 preview builds.
+
+### Project Updates
+
+- Updated CI/CD workflows.
+- Updated development tooling configuration.
+
+## [6.3.3] - 2026-04-28
+
+### Fixed
+
+- Fixed header parameter editor losing changes when editing name or value fields.
+
+### Security
+
+- Patched transitive dependencies with known vulnerabilities, including a critical CVE in `protobufjs`.
 
 ### Changed
 


### PR DESCRIPTION
## Why

Lifecycle scripts (`postinstall`, `prepare`, etc.) run arbitrary code during `npm install` and are
a common supply-chain attack vector.

## What changed

- Added `.npmrc` with `ignore-scripts=true`

## Notes

No dependencies in `package-lock.json` declare lifecycle scripts, so existing installs are
unaffected.

## References

- [npm docs](https://docs.npmjs.com/cli/v10/using-npm/scripts#a-note-on-a-common-anti-pattern)

## Test plan

- [ ] `npm install` completes successfully with `.npmrc` in place