### PR TITLE
chore: migrate CI workflows to plugin-ci-workflows v8.0.0 (GATB)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
   cd:
     name: CD
     needs: stamp-changelog
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.0
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
Migrates CI/CD workflows to `plugin-ci-workflows` v8.0.0, which introduces GATB (GitHub App Token Broker) for short-lived token authentication.

## Changes
- Bump `plugin-ci-workflows` ref from current version to `ci-cd-workflows/v8.0.0` (pinned to commit SHA `a9583870`)

## Why
Migrating to v8 is mandatory. Older versions will stop working once the long-lived GitHub App token is revoked.

## Related
A paired PR in `deployment_tools` will add the GATB configuration for repos that need it (docs publishing to website, stamp-changelog token).

See the [migration guide](https://github.com/grafana/grafana-catalog-team/blob/main/docs/plugins-ci-github-actions/070-gatb-migration.md) for details.