### PR TITLE
Keep form values in sync with the selected variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.5] - 2026-06-01
+
+### Fixed
+
+- Fixed form values lagging behind the selected variable on dashboard refresh when `Synchronize with data` is enabled.
+
 ## [6.3.4] - 2026-05-21
 
 ### Fixed

--- a/src/components/FormPanel/FormPanel.test.tsx
+++ b/src/components/FormPanel/FormPanel.test.tsx
@@ -2208,6 +2208,80 @@ describe('Panel', () => {
          */
         expect(fetch).toHaveBeenCalledTimes(1);
       });
+
+      it('Should use latest replaceVariables when debounced refresh fires after variable change', async () => {
+        jest.useFakeTimers();
+
+        const makeReplaceVariables = (url: string) =>
+          jest.fn((str: unknown) => (typeof str === 'string' ? str.replace('${myVar}', url) : str));
+
+        try {
+          jest.mocked(fetch).mockImplementation(() =>
+            Promise.resolve({
+              ok: true,
+              json: () => Promise.resolve({}),
+            } as any)
+          );
+
+          const { rerender } = await act(async () =>
+            render(
+              getComponent({
+                props: { replaceVariables: makeReplaceVariables('initial-url'), eventBus },
+                options: {
+                  initial: { url: '${myVar}', method: RequestMethod.GET },
+                  sync: true,
+                },
+              })
+            )
+          );
+
+          expect(fetch).toHaveBeenCalledWith('initial-url', expect.anything());
+
+          /**
+           * Publish RefreshEvent — starts the 250ms debounce timer, does not fire yet
+           */
+          await act(async () => {
+            eventBus.publish(new RefreshEvent());
+          });
+
+          /**
+           * Variable changes: new replaceVariables reference (as Grafana does on variable change)
+           */
+          await act(async () =>
+            rerender(
+              getComponent({
+                props: { replaceVariables: makeReplaceVariables('updated-url'), eventBus },
+                options: {
+                  initial: { url: '${myVar}', method: RequestMethod.GET },
+                  sync: true,
+                },
+              })
+            )
+          );
+
+          /**
+           * The rerender with sync:true triggers initialRequest() directly via the effect —
+           * clear the mock so subsequent assertions isolate only the debounce-fired call.
+           */
+          jest.mocked(fetch).mockClear();
+
+          /**
+           * Advance past the debounce delay — the pending timer fires, then async fetch resolves
+           */
+          act(() => {
+            jest.advanceTimersByTime(300);
+          });
+          await act(async () => {});
+
+          /**
+           * Debounce must have used the latest initialRequest (updated-url), not the stale one (initial-url)
+           */
+          expect(fetch).not.toHaveBeenCalledWith('initial-url', expect.anything());
+          expect(fetch).toHaveBeenCalledWith('updated-url', expect.anything());
+        } finally {
+          jest.useRealTimers();
+        }
+      });
     });
   });
 

--- a/src/components/FormPanel/FormPanel.tsx
+++ b/src/components/FormPanel/FormPanel.tsx
@@ -853,16 +853,21 @@ export const FormPanel: React.FC<Props> = ({
    * below never closes over a stale `replaceVariables` / `data.series`.
    */
   const initialRequestRef = useRef(initialRequest);
-  initialRequestRef.current = initialRequest;
+  useEffect(() => {
+    initialRequestRef.current = initialRequest;
+  }, [initialRequest]);
 
-  // eslint-disable-next-line react-hooks/refs -- debounce wraps the ref read, does not call it during render
-  const debouncedRequest = useMemo(() => debounce(() => initialRequestRef.current(), 250), []);
+  const debouncedRequest = useMemo(
+    // eslint-disable-next-line react-hooks/refs -- debounce wraps the ref read, does not call it during render
+    () => debounce(() => initialRequestRef.current(), 250),
+    []
+  );
 
   useEffect(() => {
     return () => {
       debouncedRequest.cancel();
     };
-  }, []);
+  }, [debouncedRequest]);
 
   /**
    * Execute Initial Request on dashboard or data update

--- a/src/components/FormPanel/FormPanel.tsx
+++ b/src/components/FormPanel/FormPanel.tsx
@@ -849,32 +849,20 @@ export const FormPanel: React.FC<Props> = ({
   }, [datasourceRequest, elements, executeCustomCode, initialRef, initialRequest, options.update, replaceVariables]);
 
   /**
-   * Latest initialRequest, read by the stable debounced wrapper below so it
-   * always uses fresh `data.series` / `replaceVariables` instead of a stale
-   * closure from a previous render.
+   * Always holds the latest initialRequest so the stable debounced wrapper
+   * below never closes over a stale `replaceVariables` / `data.series`.
    */
   const initialRequestRef = useRef(initialRequest);
-  useEffect(() => {
-    initialRequestRef.current = initialRequest;
-  }, [initialRequest]);
+  initialRequestRef.current = initialRequest;
 
-  /**
-   * Debounced Refresh - stable wrapper, single pending timer, latest request.
-   */
-  const debouncedRequest = useMemo(
-    // eslint-disable-next-line react-hooks/refs -- debounce wraps the ref read, does not call it during render
-    () => debounce(() => initialRequestRef.current(), 250),
-    []
-  );
+  // eslint-disable-next-line react-hooks/refs -- debounce wraps the ref read, does not call it during render
+  const debouncedRequest = useMemo(() => debounce(() => initialRequestRef.current(), 250), []);
 
-  /**
-   * Cancel pending debounce on unmount
-   */
   useEffect(() => {
     return () => {
       debouncedRequest.cancel();
     };
-  }, [debouncedRequest]);
+  }, []);
 
   /**
    * Execute Initial Request on dashboard or data update

--- a/src/components/FormPanel/FormPanel.tsx
+++ b/src/components/FormPanel/FormPanel.tsx
@@ -848,10 +848,33 @@ export const FormPanel: React.FC<Props> = ({
     setLoading(LoadingMode.NONE);
   }, [datasourceRequest, elements, executeCustomCode, initialRef, initialRequest, options.update, replaceVariables]);
 
-  const debouncedRequest = useMemo(() => {
-    // eslint-disable-next-line react-hooks/refs -- debounce wraps the function, does not call it during render
-    return debounce(initialRequest, 250);
+  /**
+   * Latest initialRequest, read by the stable debounced wrapper below so it
+   * always uses fresh `data.series` / `replaceVariables` instead of a stale
+   * closure from a previous render.
+   */
+  const initialRequestRef = useRef(initialRequest);
+  useEffect(() => {
+    initialRequestRef.current = initialRequest;
   }, [initialRequest]);
+
+  /**
+   * Debounced Refresh - stable wrapper, single pending timer, latest request.
+   */
+  const debouncedRequest = useMemo(
+    // eslint-disable-next-line react-hooks/refs -- debounce wraps the ref read, does not call it during render
+    () => debounce(() => initialRequestRef.current(), 250),
+    []
+  );
+
+  /**
+   * Cancel pending debounce on unmount
+   */
+  useEffect(() => {
+    return () => {
+      debouncedRequest.cancel();
+    };
+  }, [debouncedRequest]);
 
   /**
    * Execute Initial Request on dashboard or data update


### PR DESCRIPTION
Issue potentially introduced in [#619](https://github.com/volkovlabs/business-forms/pull/619).

The debounced refresh wrapper added in 6.3.0 was rebuilt on every render where `initialRequest` changed but its pending 250ms `setTimeout` was never cancelled, so after a variable change the orphan timer fired with a stale `initialRequest` closure and overwrote the form with the **previously** selected variable's values.

This PR makes the debounce wrapper stable (created once) and routes through a ref so it always invokes the latest `initialRequest`, and cancels any pending call on unmount.

Before

https://github.com/user-attachments/assets/16b72054-95f3-4c78-a223-5eaa8dd61743



After

https://github.com/user-attachments/assets/8f4afa28-37ba-4c81-a9b3-d6597171d358

Fixes https://github.com/grafana/support-escalations/issues/22589

Test-
[Cost Center Forecast (Bug Repro)-1780340490050.json](https://github.com/user-attachments/files/28477595/Cost.Center.Forecast.Bug.Repro.-1780340490050.json)
